### PR TITLE
Remove cart flash

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -24,7 +24,7 @@ class CartsController < ApplicationController
   def destroy
     @cart.remove_item(item_id)
     session[:cart] = @cart.contents
-    cart_link = "<a href=\"#{url_for(item)}\">#{item.name}</a>"
+    cart_link = "<a href=\"#{item_path(item)}\">#{item.name}</a>"
     flash[:notice] = "Successfully removed #{cart_link} from your cart"
     redirect_to cart_path
   end

--- a/spec/features/cart/user_can_remove_item_from_cart_spec.rb
+++ b/spec/features/cart/user_can_remove_item_from_cart_spec.rb
@@ -17,10 +17,19 @@ RSpec.feature 'visitor can remove an item in the cart' do
       click_on "Remove"
 
       expect(current_path).to eq("/cart")
-      # expect(page).to have_css(".alert-success", text: "Successfully removed #{item.name} from your cart")
-      expect(page).to have_content("Successfully removed #{item.name} from your cart")
-      expect(page).not_to have_link("#{item.name}", href: item_path(item))
-      expect(page).to have_content("Cart: 0")
+
+      within('.alert-success') do
+        expect(page).to have_content("Successfully removed #{item.name} from your cart")
+        expect(page).to have_link item.name, href: item_path(item)
+      end
+
+      within('.table') do
+        expect(page).not_to have_link item.name, href: item_path(item)
+      end
+
+      within ('header') do
+        expect(page).to have_content("Cart: 0")
+      end
     end
 
     scenario 'a visitor sees and removes multiple items from the cart' do
@@ -39,7 +48,7 @@ RSpec.feature 'visitor can remove an item in the cart' do
       click_on "Remove"
 
       expect(current_path).to eq("/cart")
-      # save_and_open_page
+
       within('.alert-success') do
         expect(page).to have_content("Successfully removed #{item.name} from your cart")
         expect(page).to have_link item.name, href: item_path(item)

--- a/spec/features/cart/user_can_remove_item_from_cart_spec.rb
+++ b/spec/features/cart/user_can_remove_item_from_cart_spec.rb
@@ -39,10 +39,19 @@ RSpec.feature 'visitor can remove an item in the cart' do
       click_on "Remove"
 
       expect(current_path).to eq("/cart")
-      # expect(page).to have_css(".alert-success", text: "Successfully removed #{item.name} from your cart")
-      expect(page).to have_content("Successfully removed #{item.name} from your cart")
-      expect(page).not_to have_link("#{item.name}", href: item_path(item))
-      expect(page).to have_content("Cart: 0")
+      # save_and_open_page
+      within('.alert-success') do
+        expect(page).to have_content("Successfully removed #{item.name} from your cart")
+        expect(page).to have_link item.name, href: item_path(item)
+      end
+
+      within('.table') do
+        expect(page).not_to have_link item.name, href: item_path(item)
+      end
+
+      within ('header') do
+        expect(page).to have_content("Cart: 0")
+      end
     end
   end
 end


### PR DESCRIPTION
Fix URL in flash message on cart when item removed.

URL was incorrect and spec's were testing the wrong things